### PR TITLE
 #2 > Panels should have classes with names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ return [
          'field' => true|false, // Enable/Disable the field name classes
          'resource' => true|false, // Enable/Disable the resource name classes
          'flex_group' => true|false, // Enable/Disable the Nova Flexible Content Layout Groups classes
+         'panel' => true|false, // Enable/Disable the panel name classes
          'prefix'=> [
             'component' => 'alternative-component-', // Component prefix
             'field' => 'alternative-field-', // Field prefix
             'resource' => 'alternative-resource-', // Resource prefix
             'flex_group' => 'alternative-flex-group-' // Nova Flexible Content Layout Group prefix
+            'panel' => 'alternative-panel-', // Component prefix
          ]
     ]
 

--- a/resources/js/asset.js
+++ b/resources/js/asset.js
@@ -26,6 +26,7 @@ Nova.bootingCallbacks.unshift(app => {
                     if (themeConfig.field === true) this.addThemingClass(this.$props?.field?.attribute, themeConfig.prefix?.field ?? `field-`);
                     if (themeConfig.resource === true) this.addThemingClass(this.$props?.resourceName, themeConfig.prefix?.resource ?? `resource-`);
                     if (themeConfig.flexGroup === true) this.addThemingClass(this.$props?.group?.name, themeConfig.prefix?.flexGroup ?? `flex-group-`);
+                    if (themeConfig.panel === true) this.addThemingClass(this.$props?.panel?.name, themeConfig.prefix?.panel ?? `panel-`)
                 }
             },
             addThemingClass(cssClass, prefix="") {

--- a/src/AssetServiceProvider.php
+++ b/src/AssetServiceProvider.php
@@ -22,11 +22,13 @@ class AssetServiceProvider extends ServiceProvider {
                     "field" => config("nova.theming.field", true),
                     "resource" => config("nova.theming.resource", true),
                     "flexGroup" => config("nova.theming.flex_group", true),
+                    "panel" => config("nova.theming.panel", true),
                     'prefix'=> [
                         'component' => config("nova.theming.prefix.component", 'component-'),
                         'field' => config("nova.theming.prefix.field", 'field-'),
                         'resource' => config("nova.theming.prefix.resource", 'resource-'),
                         'flexGroup' => config("nova.theming.prefix.flex_group", 'flex-group-'),
+                        'panel' => config("nova.theming.prefix.panel", 'panel-'),
                      ]
                 ]
             ]);


### PR DESCRIPTION
- Added support for named panels
- Updated README.md

Note: I did not recompile dist/js/asset.js yet, `npm run prod` doesn't seem to recompile it on my local setup & the `npm run watch` version isn't minified.